### PR TITLE
Added mechanism to handle the database credentials issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ gradle-app.setting
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+

--- a/src/main/java/com/umbr3114/ServiceLocator.java
+++ b/src/main/java/com/umbr3114/ServiceLocator.java
@@ -1,10 +1,9 @@
 package com.umbr3114;
 
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import com.umbr3114.common.DatabaseCredentials;
+import com.umbr3114.data.MongoClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,13 +28,20 @@ public class ServiceLocator {
     }
 
     private void initializeDbService() {
-        MongoClientSettings mongoSettings;
-        mongoSettings = MongoClientSettings.builder().
-                applyConnectionString(new ConnectionString("mongodb+srv://umbrella-dev:SeYYB0kZy7AmhoaG@cluster0-urisd.gcp.mongodb.net/test?retryWrites=true&w=majority"))
-                .retryWrites(true)
-                .build();
+        DatabaseCredentials mongoCredentials;
 
-        mongoClient = MongoClients.create(mongoSettings);
+        try {
+            mongoCredentials = DatabaseCredentials.fromEnvironment();
+        } catch (IllegalArgumentException e) {
+            // todo retry this with a file-based approach
+            log.error("Database credentials are missing - cannot continue!");
+            throw new IllegalStateException();
+        }
+
+        mongoClient = MongoClientFactory.create(
+                mongoCredentials.getUsername(),
+                mongoCredentials.getPassword()
+        );
 
         dbService = mongoClient.getDatabase("umbrella-data");
     }

--- a/src/main/java/com/umbr3114/common/DatabaseCredentials.java
+++ b/src/main/java/com/umbr3114/common/DatabaseCredentials.java
@@ -1,0 +1,31 @@
+package com.umbr3114.common;
+
+public class DatabaseCredentials {
+
+    private String dbUsername;
+    private String dbPassword;
+
+    public DatabaseCredentials(String user, String password) {
+
+        if ((user == null || user.isEmpty()) && (password == null || password.isEmpty())){
+            throw new IllegalArgumentException();
+        }
+
+        this.dbUsername = user;
+        this.dbPassword = password;
+    }
+
+    public String getPassword() {
+        return dbPassword;
+    }
+
+    public String getUsername() {
+        return dbUsername;
+    }
+
+    public static DatabaseCredentials fromEnvironment() {
+        return new DatabaseCredentials(System.getenv("MONGO_USER"), System.getenv("MONGO_PASS"));
+    }
+
+
+}

--- a/src/main/java/com/umbr3114/data/MongoClientFactory.java
+++ b/src/main/java/com/umbr3114/data/MongoClientFactory.java
@@ -1,0 +1,23 @@
+package com.umbr3114.data;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+
+public class MongoClientFactory {
+
+    public static MongoClient create(String dbUser, String dbPassword) {
+        String connectionString = String.format(
+                "mongodb+srv://%s:%s@cluster0-urisd.gcp.mongodb.net/umbrella-dev?retryWrites=true&w=majority",
+                dbUser,
+                dbPassword
+        );
+        MongoClientSettings mongoSettings;
+        mongoSettings = MongoClientSettings.builder().
+                applyConnectionString(new ConnectionString(connectionString))
+                .retryWrites(true)
+                .build();
+        return MongoClients.create(mongoSettings);
+    }
+}


### PR DESCRIPTION
Creation of a MongoClient was handed off to a new MongoClientFactory
A DatabaseCredentials class was created to encapsulate database credentials

ServiceLocator was updated to use the factory and credential class to create the MongoClient object

DatabaseCredentials is created from two environment variables, if they are missing, the project WILL NOT RUN

MONGO_USER
MONGO_PASS