### PR TITLE
Utility: Request Input helper

### DIFF
--- a/docs/RequestParamHelper-usage.md
+++ b/docs/RequestParamHelper-usage.md
@@ -1,0 +1,43 @@
+# RequestParamHelper
+
+RequestParamHelper is a utility class to easily extract parameters out of Spark POST requests. The main motivation for this class is when a JSON object is sent as a body of parameters in a POST request. This class allows you to easily retrieve parameters in a key/value fashion. So instead of having to deserialize JSON every time you want to check if a parameter was set or get its value, you don't have to. This class does that for you.
+
+**ALL VALUES ARE RETURNED AS A STRING.** So if you are expecting an integer, you will have to use something like `Integer.parseInt()` to get the integer value.
+
+**NOTE:** This class does not support JSON values that are other objects or arrays.
+
+# Usage
+Method | Description | Returns
+:--- | :---: | ---:
+RequestParamHelper(Request) | **Constructor**. This requires the request object as a parameter | RequestParamHelper
+hasKey(String) | This returns if the parameter key was sent in the request or not | true/false
+valueOf(String) | Returns string value of parameter key | String/null
+
+## Example
+
+If a POST request was sent to the endpoint, with a JSON body that looks like this
+
+```json
+{
+    "username":"someusername",
+    "email":"somewhere@somewhere.net",
+    "age":20
+}
+```
+This is how you can use this class to get the "username" attribute from the JSON object.
+```java
+public static Route someRoute = ((request, response) -> {
+    RequestParamHelper params = new RequestParamHelper(request);
+    String username;
+
+    if (!params.hasKey("username")) {
+        // return some error
+    }
+
+    username = params.valueOf("username");
+    
+    // .....
+    // do something with username
+    
+});
+```

--- a/src/main/java/com/umbr3114/common/JSONParamDeserializationStrategy.java
+++ b/src/main/java/com/umbr3114/common/JSONParamDeserializationStrategy.java
@@ -7,9 +7,16 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Encapsulates logic that handles deserialization of JSON parameter string
+ */
 class JSONParamDeserializationStrategy implements ParamDeserializationStrategy {
     private String requestBody;
 
+    /**
+     * Default Constructor
+     * @param reqBody JSON String that is to be deserialized
+     */
     public JSONParamDeserializationStrategy(String reqBody) {
         this.requestBody = reqBody;
     }

--- a/src/main/java/com/umbr3114/common/JSONParamDeserializationStrategy.java
+++ b/src/main/java/com/umbr3114/common/JSONParamDeserializationStrategy.java
@@ -1,0 +1,36 @@
+package com.umbr3114.common;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+class JSONParamDeserializationStrategy implements ParamDeserializationStrategy {
+    private String requestBody;
+
+    public JSONParamDeserializationStrategy(String reqBody) {
+        this.requestBody = reqBody;
+    }
+
+    @Override
+    public Map<String, String> deserializeToMap() {
+        HashMap<String, String> paramMap;
+        // Thank you https://www.baeldung.com/jackson-map
+        TypeReference<HashMap<String, String>> typeReference;
+        ObjectMapper mapper;
+
+        typeReference = new TypeReference<HashMap<String, String>>() { };
+        mapper = new ObjectMapper();
+
+        try {
+            paramMap = mapper.readValue(requestBody, typeReference);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        return paramMap;
+    }
+}

--- a/src/main/java/com/umbr3114/common/ParamDeserializationStrategy.java
+++ b/src/main/java/com/umbr3114/common/ParamDeserializationStrategy.java
@@ -1,0 +1,7 @@
+package com.umbr3114.common;
+
+import java.util.Map;
+
+interface ParamDeserializationStrategy {
+    Map<String, String> deserializeToMap();
+}

--- a/src/main/java/com/umbr3114/common/RequestParamHelper.java
+++ b/src/main/java/com/umbr3114/common/RequestParamHelper.java
@@ -6,6 +6,11 @@ import spark.Request;
 
 import java.util.Map;
 
+/**
+ * RequestParamHelper is a utility class to easily extract parameters out of Spark POST requests.
+ * The main motivation for this class is when a JSON object is sent as a body of parameters in a POST request.
+ * This class allows you to easily retrieve parameters in a key/value fashion
+ */
 public class RequestParamHelper {
 
     public static final String REQUEST_FORM_ENCODED = "application/x-www-form-urlencoded";
@@ -16,6 +21,10 @@ public class RequestParamHelper {
     private ParamDeserializationStrategy deserializationStrategy;
     private Map<String, String> paramMap;
 
+    /**
+     * Default constructor
+     * @param sparkRequest Request object from Spark route. Typically the request variable
+     */
     public RequestParamHelper(Request sparkRequest) {
         this.sparkRequest = sparkRequest;
 
@@ -31,6 +40,12 @@ public class RequestParamHelper {
         paramMap = deserializationStrategy.deserializeToMap();
     }
 
+    /**
+     * This constructor is package-private and is therefore not intended for use outside of this package, within the rest of the application.
+     * This constructor is mainly for unit testing purposes.
+     * @param sparkRequest Spark Requst object
+     * @param deserializationStrategy Typically a Mocked ParamDeserializationStrategy
+     */
     RequestParamHelper(Request sparkRequest, ParamDeserializationStrategy deserializationStrategy) {
         this.sparkRequest = sparkRequest;
         this.deserializationStrategy = deserializationStrategy;
@@ -38,17 +53,33 @@ public class RequestParamHelper {
         paramMap = deserializationStrategy.deserializeToMap();
     }
 
+    /**
+     * Searches for a specific parameter key in the request to determine if it exists
+     * @param key String key name that is expected in the request
+     * @return true if key exists, false if key is missing, false if key is found but String value is empty.
+     */
     public boolean hasKey(String key) {
         if (paramMap.containsKey(key)) return !paramMap.get(key).isEmpty();
         return false;
     }
 
+    /**
+     * Returns the value of a specific parameter key in the request. Always returns String
+     * @param key String name that is expected in the Request
+     * @return String value of the request parameter, null if key is missing, null if key exists but String value is empty
+     */
     public String valueOf(String key) {
         if (!hasKey(key)) return null;
 
         return paramMap.get(key);
     }
 
+    /**
+     * Determines the Strategy logic based on the Content-Type of the request
+     * Deserializing key/value pairs is vastly different if it is a URLFormEncoded request or a JSON body request.
+     * Instead of complicating this class with the logic, it is extracted to multiple Strategy classes
+     * This also allows this class to easily support other Content-Types in the future (or deal with GET params)
+     */
     private void createDeserializationStrategy() {
 
         switch (sparkRequest.headers("Content-Type")) {

--- a/src/main/java/com/umbr3114/common/RequestParamHelper.java
+++ b/src/main/java/com/umbr3114/common/RequestParamHelper.java
@@ -1,0 +1,70 @@
+package com.umbr3114.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+
+import java.util.Map;
+
+public class RequestParamHelper {
+
+    public static final String REQUEST_FORM_ENCODED = "application/x-www-form-urlencoded";
+    public static final String REQUEST_JSON_POST = "application/json";
+
+    private Request sparkRequest;
+    private final Logger log = LoggerFactory.getLogger("RequestParamHelper");
+    private ParamDeserializationStrategy deserializationStrategy;
+    private Map<String, String> paramMap;
+
+    public RequestParamHelper(Request sparkRequest) {
+        this.sparkRequest = sparkRequest;
+
+        if (sparkRequest == null) {
+            log.error("Passed a null Spark Request object.");
+            throw new IllegalArgumentException("Passed a null Spark Request object.");
+        }
+
+        // determine what type of request is going to be deserialized
+        createDeserializationStrategy();
+
+        // set the map
+        paramMap = deserializationStrategy.deserializeToMap();
+    }
+
+    RequestParamHelper(Request sparkRequest, ParamDeserializationStrategy deserializationStrategy) {
+        this.sparkRequest = sparkRequest;
+        this.deserializationStrategy = deserializationStrategy;
+
+        paramMap = deserializationStrategy.deserializeToMap();
+    }
+
+    public boolean hasKey(String key) {
+        if (paramMap.containsKey(key)) return !paramMap.get(key).isEmpty();
+        return false;
+    }
+
+    public String valueOf(String key) {
+        if (!hasKey(key)) return null;
+
+        return paramMap.get(key);
+    }
+
+    private void createDeserializationStrategy() {
+
+        switch (sparkRequest.headers("Content-Type")) {
+            case REQUEST_FORM_ENCODED:
+                deserializationStrategy = new URLFormDeserializationStrategy(sparkRequest);
+                break;
+            case REQUEST_JSON_POST:
+                deserializationStrategy = new JSONParamDeserializationStrategy(sparkRequest.body());
+                break;
+            default:
+                log.error("Unsupported request Content-Type");
+                throw new UnsupportedContentTypeException();
+        }
+    }
+
+    public ParamDeserializationStrategy getDeserializationStrategy() {
+        return deserializationStrategy;
+    }
+}

--- a/src/main/java/com/umbr3114/common/URLFormDeserializationStrategy.java
+++ b/src/main/java/com/umbr3114/common/URLFormDeserializationStrategy.java
@@ -1,0 +1,28 @@
+package com.umbr3114.common;
+
+import spark.Request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class URLFormDeserializationStrategy implements ParamDeserializationStrategy {
+
+    Request request;
+    public URLFormDeserializationStrategy(Request sparkRequest) {
+        request = sparkRequest;
+    }
+
+    @Override
+    public Map<String, String> deserializeToMap() {
+        Map<String, String> paramMap;
+
+        paramMap = new HashMap<>(request.queryParams().size());
+
+        for(String paramKey: request.queryParams()) {
+            paramMap.put(paramKey, request.queryParams(paramKey));
+        }
+        return paramMap;
+    }
+
+
+}

--- a/src/main/java/com/umbr3114/common/UnsupportedContentTypeException.java
+++ b/src/main/java/com/umbr3114/common/UnsupportedContentTypeException.java
@@ -1,0 +1,4 @@
+package com.umbr3114.common;
+
+public class UnsupportedContentTypeException extends RuntimeException {
+}

--- a/src/main/java/com/umbr3114/common/UnsupportedContentTypeException.java
+++ b/src/main/java/com/umbr3114/common/UnsupportedContentTypeException.java
@@ -1,4 +1,7 @@
 package com.umbr3114.common;
 
+/**
+ * Exception for when a Content-Type is passed to the RequestParamHelper that is not supported
+ */
 public class UnsupportedContentTypeException extends RuntimeException {
 }

--- a/src/main/java/com/umbr3114/controllers/DropController.java
+++ b/src/main/java/com/umbr3114/controllers/DropController.java
@@ -1,6 +1,7 @@
 package com.umbr3114.controllers;
 
 import com.umbr3114.ServiceLocator;
+import com.umbr3114.common.RequestParamHelper;
 import com.umbr3114.data.CollectionFactory;
 import com.umbr3114.models.DropModel;
 import org.eclipse.jetty.http.HttpStatus;
@@ -47,4 +48,5 @@ public class DropController {
 
 
     });
+
 }

--- a/src/test/java/com/umbr3114/auth/SparkSessionTests.java
+++ b/src/test/java/com/umbr3114/auth/SparkSessionTests.java
@@ -7,9 +7,6 @@ import spark.Request;
 import spark.Response;
 import spark.Session;
 
-import static org.mockito.Mockito.verify;
-
-
 public class SparkSessionTests {
 
     @Mock

--- a/src/test/java/com/umbr3114/common/JSONParamDeserializationStrategyTests.java
+++ b/src/test/java/com/umbr3114/common/JSONParamDeserializationStrategyTests.java
@@ -1,0 +1,47 @@
+package com.umbr3114.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnit4.class)
+public class JSONParamDeserializationStrategyTests {
+
+    @Test
+    public void test_deserializeToMap_deserializesBasicJSON() {
+        Map<String, String> testMap = new HashMap<>();
+        Map<String, String> resultMap;
+        JSONParamDeserializationStrategy strategy;
+        String basicJsonString = "{\"param1\":\"val1\", \"param2\":\"val2\", \"param3\":\"val3\"}";
+
+        testMap.put("param1", "val1");
+        testMap.put("param2", "val2");
+        testMap.put("param3", "val3");
+
+        strategy = new JSONParamDeserializationStrategy(basicJsonString);
+        resultMap = strategy.deserializeToMap();
+        Assert.assertEquals(testMap, resultMap);
+    }
+
+    @Test
+    public void test_deserializeToMap_deserializeJsonWithNonStringParameter() {
+        String jsonString = "{\"param1\":1, \"param2\":2, \"param3\":3}";
+        Map<String, String> resultMap;
+        Map<String, String> testMap = new HashMap<>();
+        JSONParamDeserializationStrategy strategy = new JSONParamDeserializationStrategy(jsonString);
+
+        testMap.put("param1", "1");
+        testMap.put("param2", "2");
+        testMap.put("param3", "3");
+
+        resultMap = strategy.deserializeToMap();
+
+        Assert.assertEquals(testMap, resultMap);
+
+
+    }
+}

--- a/src/test/java/com/umbr3114/common/RequestParamHelperTests.java
+++ b/src/test/java/com/umbr3114/common/RequestParamHelperTests.java
@@ -1,0 +1,189 @@
+package com.umbr3114.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import spark.Request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequestParamHelperTests {
+
+    @Mock
+    ParamDeserializationStrategy fakeStrategy;
+    @Mock
+    Request fakeSparkRequest;
+
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void test_choosesCorrectStrategy_JSON() {
+        RequestParamHelper helper;
+        // mocks
+        when(fakeSparkRequest.headers("Content-Type")).thenReturn(RequestParamHelper.REQUEST_JSON_POST);
+        when(fakeSparkRequest.body()).thenReturn("{}");
+        
+        helper = new RequestParamHelper(fakeSparkRequest);
+
+        Assert.assertTrue(helper.getDeserializationStrategy() instanceof JSONParamDeserializationStrategy);
+    }
+
+    @Test
+    public void test_choosesCorrectStrategy_FORM() {
+        RequestParamHelper helper;
+        // mocks
+        when(fakeSparkRequest.headers("Content-Type")).thenReturn(RequestParamHelper.REQUEST_FORM_ENCODED);
+
+        helper = new RequestParamHelper(fakeSparkRequest);
+
+        Assert.assertTrue(helper.getDeserializationStrategy() instanceof URLFormDeserializationStrategy);
+    }
+
+    @Test
+    public void test_choosesCorrectStrategy_unsupportedContentType_throwsException() {
+        boolean throwsException = false;
+        RequestParamHelper helper;
+
+        when(fakeSparkRequest.headers("Content-Type")).thenReturn("WRONG");
+
+        try {
+            helper = new RequestParamHelper(fakeSparkRequest);
+        } catch (UnsupportedContentTypeException e) {
+            throwsException = true;
+        }
+        Assert.assertTrue(throwsException);
+    }
+
+    @Test
+    public void test_hasKey_mapHasKeyReturnsTrue() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        testMap.put(testKey, "item");
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        Assert.assertTrue(helper.hasKey(testKey));
+    }
+
+    @Test
+    public void test_hasKey_mapDoesNotHaveKeyReturnsFalse() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        testMap.put("SomeOtherKey", "item");
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        Assert.assertFalse(helper.hasKey(testKey));
+    }
+
+    @Test
+    public void test_hasKey_mapHasKeyButEmptyStringReturnsFalse() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        testMap.put(testKey, "");
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        Assert.assertFalse(helper.hasKey(testKey));
+    }
+
+    @Test
+    public void test_valueOf_mapHasKeyReturnsValue() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        String testValue = "item";
+        String result;
+
+        testMap.put(testKey, testValue);
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        result = helper.valueOf(testKey);
+        Assert.assertEquals(testValue, result);
+    }
+
+    @Test
+    public void test_valueOf_mapDoesNotHaveKeyReturnsNull() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        String testValue = "item";
+        String result;
+
+        testMap.put(testKey, testValue);
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        result = helper.valueOf("NOTINTHEMAP");
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void test_valueOf_mapHasKeyButEmptyStringReturnsNull() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+        String testKey = "key";
+        String result;
+
+        testMap.put(testKey, "");
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+        result = helper.valueOf(testKey);
+
+        Assert.assertNull(result);
+    }
+
+
+    // Nice template method for other tests in this class
+    @Ignore
+    public void test_something() {
+        RequestParamHelper helper;
+        Map<String, String> testMap = new HashMap<>();
+
+        // setup fakes
+        when(fakeStrategy.deserializeToMap()).thenReturn(testMap);
+
+
+        // create object
+        helper = new RequestParamHelper(fakeSparkRequest, fakeStrategy);
+
+        // test something!
+    }
+
+
+}

--- a/src/test/java/com/umbr3114/common/URLFormDeserialzationStrategyTests.java
+++ b/src/test/java/com/umbr3114/common/URLFormDeserialzationStrategyTests.java
@@ -1,0 +1,63 @@
+package com.umbr3114.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import spark.Request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class URLFormDeserialzationStrategyTests {
+
+    @Mock
+    public Request fakeSparkRequest;
+
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void test_derserializeToMap_deserializes() {
+        URLFormDeserializationStrategy strategy;
+        Map<String, String> testMap = new HashMap<>();
+        Map<String, String> resultMap;
+
+        testMap.put("param1", "val1");
+        testMap.put("param2", "val2");
+        testMap.put("param3", "val3");
+
+        when(fakeSparkRequest.queryParams()).thenReturn(testMap.keySet());
+        // this is a little hacky, but eh it works
+        for(String key : testMap.keySet()) {
+            when(fakeSparkRequest.queryParams(key)).thenReturn(testMap.get(key));
+        }
+
+        strategy = new URLFormDeserializationStrategy(fakeSparkRequest);
+        resultMap = strategy.deserializeToMap();
+
+        Assert.assertEquals(testMap, resultMap);
+    }
+
+    @Test
+    public void test_deserializeToMap_queryParamsEmpty_returnsEmptyMap(){
+        URLFormDeserializationStrategy strategy;
+        Map<String, String> testMap = new HashMap<>();
+        Map<String, String> resultMap;
+
+        when(fakeSparkRequest.queryParams()).thenReturn(testMap.keySet());
+
+        strategy = new URLFormDeserializationStrategy(fakeSparkRequest);
+        resultMap = strategy.deserializeToMap();
+        Assert.assertEquals(testMap, resultMap);
+    }
+
+}


### PR DESCRIPTION
The idea of this class is to help with fetching possible parameters for API endpoints. It is geared toward POST requests and primarily consuming JSON body text.
This class should make it easier in the rest of the application to extract parameters from JSON objects sent to parameterized POST endpoints.

This closes issue #77 