### PR TITLE
Delete route bugfix

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -50,10 +50,6 @@
 }
 ```
 
-* POST `/user/subscribe`
-* GET `/user/subscribed`
-* POST `/user/unsubscribe`
-
 # Drops
 ### POST `/drops/create`
 > Accepts JSON
@@ -71,6 +67,39 @@
     "message":"success/fail message"
 }
 ```
+
+### POST `/drops/delete`
+> Accepts JSON
+```json
+{
+  "drop_id":"<dropId>"
+}
+```
+> Returns JSON
+```json
+{
+    "status":number,
+    "message":"success/fail message"
+}
+```
+
+### PUT `/drops/update`
+> Accepts JSON
+```json
+{
+  "drop_id":"<dropId>",
+  "topic":"<new drop topic>"
+}
+```
+> Returns JSON
+```json
+{
+    "status":number,
+    "message":"success/fail message"
+}
+```
+
+
 
 ### POST `/drops/managemod`
 > Accepts JSON

--- a/src/main/java/com/umbr3114/Main.java
+++ b/src/main/java/com/umbr3114/Main.java
@@ -52,8 +52,11 @@ public class Main {
         before("/user/info", new AuthCheck());
         get("/user/info", AuthRoutes.userInfo, new JsonResponse());
 
-        put("/drops/:dbname/update", DropController.updateDrop);
-        delete("/drops/:dropName/delete", DropController.deleteDrop);
+        before("/drops/delete", new AuthCheck());
+        before("/drops/update", new AuthCheck());
+        put("/drops/update", DropController.updateDrop, new JsonResponse());
+        delete("/drops/delete", DropController.deleteDrop, new JsonResponse());
+
         before("/drops/create", new AuthCheck());
         post("/drops/create", DropController.addDrop, new JsonResponse());
         get("/drops/list", DropController.listDrops, new JsonResponse());

--- a/src/main/java/com/umbr3114/ServiceLocator.java
+++ b/src/main/java/com/umbr3114/ServiceLocator.java
@@ -1,5 +1,6 @@
 package com.umbr3114;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.client.MongoClient;
@@ -54,6 +55,7 @@ public class ServiceLocator {
 
     private void initJsonMapper() {
         jsonMapper = new ObjectMapper();
+        jsonMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     public MongoClient mongoClient() {

--- a/src/main/java/com/umbr3114/controllers/DropController.java
+++ b/src/main/java/com/umbr3114/controllers/DropController.java
@@ -1,5 +1,6 @@
 package com.umbr3114.controllers;
 
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.model.Filters;
 import com.umbr3114.Main;
 import com.umbr3114.ServiceLocator;
@@ -52,9 +53,13 @@ public class DropController {
         drop.title = title;
         drop.topic = topic;
 
-        // todo enforce index on title
         dropCollection = new CollectionFactory<DropModel>(ServiceLocator.getService().dbService(), DropModel.class).getCollection();
-        dropCollection.save(drop);
+
+        try {
+            dropCollection.save(drop);
+        } catch (MongoWriteException e) {
+            halt(HttpStatus.BAD_REQUEST_400, new GeneralResponse(HttpStatus.BAD_REQUEST_400, "drop already exists").toJSON());
+        }
 
         return new GeneralResponse(HttpStatus.OK_200, "successful");
 


### PR DESCRIPTION
This P/R will fix #109 

/drops/delete actually checks for authorization before performing the delete.
/drops/update actually checks for authorization before invoking route

both routes are now updated in the endpoint documentation
both routes have also been renamed to NOT take the dropTitle within their paths, since that was never used in the route.